### PR TITLE
remove dependency to lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,5 @@
     "sinon-as-promised": "^4.0.3",
     "sinon-chai": "^3.6.0"
   },
-  "dependencies": {
-    "lodash": "^4.17.21"
-  }
+  "dependencies": {}
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,3 @@
-const _ = require('lodash');
-
 /* eslint-disable no-use-before-define */
 /* eslint-disable sort-keys */
 
@@ -18,8 +16,8 @@ const types = {
   object: Symbol('object'),
 };
 
-const typesValues = _.values(types);
-const orderedTypes = _.zipObject(typesValues, Object.keys(typesValues).map(key => Number(key)));
+const typesValues = Object.values(types);
+const orderedTypes = Object.fromEntries(typesValues.map((v, i) => [v, i]));
 
 const comparators = {
   [types.array]: compareArray,


### PR DESCRIPTION
This PR removes dependency to lodash package. Lodash was used only for functionality that can be replaced by `Object.values()`, `Object.keys()` and `Object.fromEntries()`. Those functions were already used by existing code and are available since node12. Removal of dependency is a patch semver change, proposing 4.0.7.

Benefit of removing the dependency is small and faster install time and reduced maintenance effort (for upstream packages, e.g. no vulnerabilities reported if lodash has a vulnerability)